### PR TITLE
Allow completion for sr-inplace

### DIFF
--- a/sunrise-commander.el
+++ b/sunrise-commander.el
@@ -3161,7 +3161,7 @@ The given PROMPT will be displayed to the user interactively."
           (if (cdr marked)
               (read-directory-name prompt)
             (read-file-name
-             prompt nil nil nil (file-name-nondirectory (car marked)) #'ignore)))
+             prompt nil nil nil (file-name-nondirectory (car marked)))))
          (progress (sr-make-progress-reporter "working" (length marked)))
          (inhibit-read-only t))
 


### PR DESCRIPTION
It's not clear to me why completion was disabled in the first place. But in any case, this pull request makes it so that I can use completion to rename-in-place a file into a subdirectory.