### PR TITLE
Modify Lisp headers for Package-Requires, Keywords and URL

### DIFF
--- a/sunrise-commander.el
+++ b/sunrise-commander.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 24 Sep 2007
 ;; Version: 6
-;; RCS Version: $Rev: 464 $
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
 ;; Keywords: files, dired, midnight commander, norton, orthodox
-;; URL: http://www.emacswiki.org/emacs/sunrise-commander.el
-;; Compatibility: GNU Emacs 22+
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-buttons.el
+++ b/sunrise-x-buttons.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 11 Jun 2008
 ;; Version: 1
-;; RCS Version: $Rev: 444 $
-;; Keywords: sunrise commander, shortcut buttons
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-buttons.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, shortcut buttons
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-checkpoints.el
+++ b/sunrise-x-checkpoints.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 29 Dec 2009
 ;; Version: 1
-;; RCS Version: $Rev: 440 $
-;; Keywords: sunrise commander, checkpoints, bookmarks
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-checkpoints.el
-;; Compatibility: GNU Emacs 23+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, checkpoints, bookmarks
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-loop.el
+++ b/sunrise-x-loop.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 27 Jun 2008
 ;; Version: 3
-;; RCS Version: $Rev: 423 $
-;; Keywords: sunrise commander, background copy rename move
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-loop.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, background copy rename move
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-mirror.el
+++ b/sunrise-x-mirror.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 4 May 2008
 ;; Version: 2
-;; RCS Version: $Rev: 423 $
-;; Keywords: sunrise commander, archives read/write
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-mirror.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, archives read/write
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-modeline.el
+++ b/sunrise-x-modeline.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 10 Oct 2009
 ;; Version: 2
-;; RCS Version: $Rev: 423 $
-;; Keywords: sunrise commander, modeline, path mode line
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-modeline.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, modeline, path mode line
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-old-checkpoints.el
+++ b/sunrise-x-old-checkpoints.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 28 Dec 2009
 ;; Version: 1
-;; RCS Version: $Rev: 449 $
-;; Keywords: sunrise commander, old checkpoints
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-old-checkpoints.el
-;; Compatibility: GNU Emacs 22
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, old checkpoints
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-popviewer.el
+++ b/sunrise-x-popviewer.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 20 Aug 2008
 ;; Version: 3
-;; RCS Version: $Rev: 444 $
-;; Keywords: sunrise commander, windows, accessibility, viewer
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-popviewer.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "25") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, windows, accessibility, viewer
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-tabs.el
+++ b/sunrise-x-tabs.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 24 Oct 2009
 ;; Version: 1
-;; RCS Version: $Rev: 446 $
-;; Keywords: sunrise commander, tabs
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-tabs.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, tabs
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-tree.el
+++ b/sunrise-x-tree.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 4 May 2010
 ;; Version: 1
-;; RCS Version: $Rev: 450 $
-;; Keywords: sunrise commander, directories tree navigation
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-tree.el
-;; Compatibility: GNU Emacs 22+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, directories tree navigation
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 

--- a/sunrise-x-w32-addons.el
+++ b/sunrise-x-w32-addons.el
@@ -7,10 +7,9 @@
 ;; Maintainer: José Alfredo Romero L. <escherdragon@gmail.com>
 ;; Created: 14 May 2011
 ;; Version: 1
-;; RCS Version: $Rev: 456 $
-;; Keywords: sunrise commander, w32, ms windows
-;; URL: http://www.emacswiki.org/emacs/sunrise-x-w32-addons.el
-;; Compatibility: GNU Emacs 23+
+;; Package-Requires: ((emacs "24.3") (cl-lib "0.5"))
+;; Keywords: files, sunrise commander, w32, ms windows
+;; URL: https://github.com/sunrise-commander/sunrise-commander
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
refs #67

Non-standard `RCS Version` and `Compatibility` headers do not have a specific meaning and are superseded by `Package-Version` and `Package-Requires` headers.

