### PR TITLE
Use isearch-unread instead of isearch-unread-key-sequence

### DIFF
--- a/sunrise-x-tree.el
+++ b/sunrise-x-tree.el
@@ -696,7 +696,7 @@ View and visit that folder."
       (funcall next-command)
       (setq key (read-key-sequence msg)
             next-command (lookup-key sr-tree-mode-map key)))
-    (isearch-unread-key-sequence (listify-key-sequence key))
+    (isearch-unread (listify-key-sequence key))
     (setq isearch-mode-end-hook-quit nil)))
 
 (defun sr-tree-focus-branch ()


### PR DESCRIPTION
fixes #71

`isearch-unread-key-sequence` has been removed in Emacs 23.4. The `isearch-unread` command is defined in Emacs 24.3, so just replace it.