### PR TITLE
Remove autoload cookie from sr-extend-with each lisp file

### DIFF
--- a/sunrise-x-buttons.el
+++ b/sunrise-x-buttons.el
@@ -294,8 +294,7 @@ Used inside the Sunrise Buttons buffer."
         ((string= mode-name "Editable Dired") (eval '(wdired-finish-edit)))
         (t (message "Already in regular mode"))))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-buttons))
+
 (provide 'sunrise-x-buttons)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-buttons))
-
 ;;; sunrise-x-buttons.el ends here

--- a/sunrise-x-loop.el
+++ b/sunrise-x-loop.el
@@ -338,8 +338,7 @@ triggered by `sr-do-rename' inside a loop scope."
   (define-key sr-mode-map "K" 'sr-do-clone)
   (define-key sr-mode-map "R" 'sr-do-rename))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-loop))
+
 (provide 'sunrise-x-loop)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-loop))
-
 ;;; sunrise-x-loop.el ends here

--- a/sunrise-x-mirror.el
+++ b/sunrise-x-mirror.el
@@ -561,8 +561,7 @@ so they are always writeable by default."
 (defun sunrise-x-mirror-unload-function ()
   (sr-ad-disable "^sr-mirror-"))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-mirror))
+
 (provide 'sunrise-x-mirror)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-mirror))
-
 ;;; sunrise-x-mirror.el ends here

--- a/sunrise-x-modeline.el
+++ b/sunrise-x-modeline.el
@@ -321,8 +321,7 @@ the Sunrise Commander, after module installation."
 (add-to-list 'desktop-minor-mode-handlers
              '(sr-modeline . sr-modeline-desktop-restore-function))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-modeline))
+
 (provide 'sunrise-x-modeline)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-modeline))
-
 ;;; sunrise-x-modeline.el ends here

--- a/sunrise-x-popviewer.el
+++ b/sunrise-x-popviewer.el
@@ -222,8 +222,8 @@ passive pane."
   (sr-ad-disable "^sr-popviewer-"))
 
 (sr-popviewer-mode (if sr-popviewer-enabled 1 -1))
+
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-popviewer))
+
 (provide 'sunrise-x-popviewer)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-popviewer))
-
 ;;; sunrise-x-popviewer.el ends here

--- a/sunrise-x-tabs.el
+++ b/sunrise-x-tabs.el
@@ -677,8 +677,7 @@ tabs in the Sunrise Commander (used for desktop support)."
 (defun sunrise-x-tabs-unload-function ()
   (sr-ad-disable "^sr-tabs-"))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-tabs))
+
 (provide 'sunrise-x-tabs)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-tabs))
-
 ;;; sunrise-x-tabs.el ends here

--- a/sunrise-x-tree.el
+++ b/sunrise-x-tree.el
@@ -1211,8 +1211,7 @@ switch to normal mode, then execute."
 (add-to-list 'desktop-buffer-mode-handlers
              '(sr-tree-mode . sr-tree-desktop-restore-buffer))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-tree))
+
 (provide 'sunrise-x-tree)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-tree))
-
 ;;; sunrise-x-tree.el ends here

--- a/sunrise-x-w32-addons.el
+++ b/sunrise-x-w32-addons.el
@@ -283,8 +283,7 @@ The names are separated by a space."
 (defun sunrise-x-w32-addons-unload-function ()
   (sr-ad-disable "^sr-w32-"))
 
+(eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-w32-addons))
+
 (provide 'sunrise-x-w32-addons)
-
-;;;###autoload (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-w32-addons))
-
 ;;; sunrise-x-w32-addons.el ends here


### PR DESCRIPTION
Recently, package autoloading is not preferred to have significant side effects.

This change temporarily breaks backward compatibility.
If you want to continue using these extensions, either require each package or add the following code to your `.emacs` file:

    (require 'sunrise-x-w32-addons)

Or you may: (when auto loaded)

    (eval-after-load 'sunrise-commander '(sr-extend-with 'sunrise-x-w32-addons))