### PR TITLE
Bugfix for M-o (sr-synchronize-panes) when other pane doesn't exist

### DIFF
--- a/sunrise-commander.el
+++ b/sunrise-commander.el
@@ -2213,6 +2213,7 @@ If the optional parameter REVERSE is non-nil, performs the
 opposite operation, ie. changes the directory in the current pane
 to that in the other one."
   (interactive "P")
+  (sr-assert-other)
   (let ((target (current-buffer)) (sr-inhibit-highlight t))
     (sr-change-window)
     (if reverse

--- a/sunrise-commander.el
+++ b/sunrise-commander.el
@@ -908,6 +908,11 @@ Uses `save-selected-window' internally."
          (unless (kill-buffer dispose)
            (kill-local-variable 'sr-current-path-faces))))))
 
+(defun sr-assert-other ()
+  "Signal an error if we have no other pane."
+  (unless (window-live-p (sr-other))
+    (error "No other Sunrise Commander pane")))
+
 (defmacro sr-in-other (form)
   "Execute FORM in the context of the passive pane.
 Helper macro for passive & synchronized navigation."

--- a/sunrise-commander.el
+++ b/sunrise-commander.el
@@ -911,7 +911,7 @@ Uses `save-selected-window' internally."
 (defun sr-assert-other ()
   "Signal an error if we have no other pane."
   (unless (window-live-p (sr-other))
-    (error "No other Sunrise Commander pane")))
+    (user-error "No other Sunrise Commander pane")))
 
 (defmacro sr-in-other (form)
   "Execute FORM in the context of the passive pane.


### PR DESCRIPTION
`sr-synchronize-panes` assumed that we have both panes (left and right). If the other pane's window had died, it would throw a backtrace. This patch fixes the bug so it gives an appropriate error message if there is no other pane to synchronize.

@zonuexe OK?