### PR TITLE
Fix things pertaining to invisible text handling

### DIFF
--- a/sunrise-tree.el
+++ b/sunrise-tree.el
@@ -154,8 +154,6 @@
 ;; file size (y).
 
 ;; All directory commands from the Sunrise Buttons extension are also supported.
-;; It is required to upgrade the Buttons extension to version 1R293 or better to
-;; make this integration work correctly, though.
 
 ;; Hey, and don't forget to enjoy ;-)
 

--- a/sunrise-w32.el
+++ b/sunrise-w32.el
@@ -209,7 +209,7 @@ Also includes some selected special folders."
 (defun sunrise-w32-entry-overlay (start end)
   "Create an invisible, tangible overlay from start to end."
   (let ((overlay (make-overlay start end)))
-    (overlay-put overlay 'invisible t)
+    (overlay-put overlay 'invisible 'sunrise)
     (overlay-put overlay 'before-string "  ")))
 
 (defun sunrise-w32-create-drivers-script ()

--- a/sunrise.el
+++ b/sunrise.el
@@ -3763,7 +3763,7 @@ pane."
                     (when (and start end)
                       (let ((old (get-text-property start 'invisible)))
                         (put-text-property
-                         (point-at-bol) (point-at-eol) 'invisible
+                         (point-at-bol) (1+ (point-at-eol)) 'invisible
                          (if (string-match-p
                               regex (buffer-substring-no-properties start end))
                              (cl-set-difference old '(sunrise-narrow))

--- a/sunrise.el
+++ b/sunrise.el
@@ -1009,7 +1009,9 @@ Used as a cache during revert operations."
 (add-hook 'kill-buffer-hook       'sunrise-kill-backup-buffer)
 (add-hook 'change-major-mode-hook 'sunrise-kill-backup-buffer)
 
-(add-to-list 'enriched-translations '(invisible (t "x-invisible")))
+(add-to-list 'enriched-translations
+             '(invisible (sunrise "x-sunrise-invisible")))
+
 (defun sunrise-enrich-buffer ()
   "Activate `enriched-mode' before saving a Sunrise buffer to a file.
 This is done so all its dired-filename attributes are kept in the file."
@@ -2343,7 +2345,8 @@ Selective hiding of specific attributes can be controlled by customizing the
                         `(display
                           ,(apply display-function-or-flag
                                   (list (buffer-substring cursor (1- (point)))))))
-                       ((null display-function-or-flag) '(invisible t))
+                       ((null display-function-or-flag)
+                        '(invisible sunrise))
                        (t nil))))
       (if sunrise-attributes-display-mask
           (cl-block block
@@ -2357,7 +2360,7 @@ Selective hiding of specific attributes can be controlled by customizing the
                     (if (>= (point) end) (cl-return-from block)))
                   sunrise-attributes-display-mask))
         (unless (>= cursor end)
-          (put-text-property cursor (1- end) 'invisible t))))))
+          (put-text-property cursor (1- end) 'invisible 'sunrise))))))
 
 (defun sunrise-display-attributes (beg end visiblep)
   "Manage the display of file attributes in the region from BEG to END.
@@ -2374,7 +2377,7 @@ if VISIBLEP is nil then shows file attributes in region, otherwise hides them."
         (forward-char 1)
         (if (not visiblep)
             (sunrise-mask-attributes (point) next)
-          (remove-text-properties (point) next '(invisible t))
+          (remove-text-properties (point) next '(invisible sunrise))
           (remove-text-properties (point) next '(display)))
         (forward-line 1)
         (setq next (dired-move-to-filename))))))

--- a/sunrise.el
+++ b/sunrise.el
@@ -3755,20 +3755,21 @@ pane."
           (when next-char
             (add-to-invisibility-spec 'sunrise-narrow)
             (let ((inhibit-read-only t))
-              (goto-char (point-min))
-              (while (not (eobp))
-                (let* ((start (dired-move-to-filename))
-                       (end (and start (dired-move-to-end-of-filename t))))
-                  (when (and start end)
-                    (let ((old (get-text-property start 'invisible)))
-                      (put-text-property
-                       (point-at-bol) (point-at-eol) 'invisible
-                       (if (string-match-p
-                            regex (buffer-substring-no-properties start end))
-                           (cl-set-difference old '(sunrise-narrow))
-                         (cl-union old '(sunrise-narrow)))))))
-                (goto-char (point-at-bol))
-                (forward-line 1)))
+              (save-excursion
+                (goto-char (point-min))
+                (while (not (eobp))
+                  (let* ((start (dired-move-to-filename))
+                         (end (and start (dired-move-to-end-of-filename t))))
+                    (when (and start end)
+                      (let ((old (get-text-property start 'invisible)))
+                        (put-text-property
+                         (point-at-bol) (point-at-eol) 'invisible
+                         (if (string-match-p
+                              regex (buffer-substring-no-properties start end))
+                             (cl-set-difference old '(sunrise-narrow))
+                           (cl-union old '(sunrise-narrow)))))))
+                  (goto-char (point-at-bol))
+                  (forward-line 1))))
             (setq next-char (read-next filter))))))))
 
 (defun sunrise-recent-files ()

--- a/sunrise.el
+++ b/sunrise.el
@@ -3724,53 +3724,53 @@ pane."
   Once narrowed and accepted, you can restore the original contents of the pane
   by pressing g (`revert-buffer')."
   (interactive)
-  (when sunrise-running
-    (sunrise-beginning-of-buffer)
-    (let ((stack nil) (filter "") (regex "") (next-char nil) (inhibit-quit t))
-      (cl-labels ((read-next (f) (read-char (concat "Fuzzy narrow: " f))))
-        (setq next-char (read-next filter))
-        (sunrise-backup-buffer)
-        (while next-char
-          (cl-case next-char
-            ((?\e ?\C-g) (setq next-char nil) (sunrise-revert-buffer))
-            (?\C-n (setq next-char nil) (sunrise-beginning-of-buffer))
-            (?\C-p (setq next-char nil) (sunrise-end-of-buffer))
-            ((?\n ?\r) (setq next-char nil))
-            ((?\b ?\d)
-             (revert-buffer)
-             (setq stack (cdr stack) filter (caar stack) regex (cdar stack))
-             (unless stack (setq next-char nil)))
-            (t
-             (setq filter (concat filter (char-to-string next-char)))
-             (if (not (eq next-char sunrise-fuzzy-negation-character))
-                 (setq next-char (char-to-string next-char)
-                       regex (if (string= "" regex) ".*" regex)
-                       regex (concat regex (regexp-quote next-char) ".*"))
-               (setq next-char (char-to-string (read-next filter))
-                     filter (concat filter next-char)
-                     regex (replace-regexp-in-string "\\.\\*\\'" "" regex)
-                     regex (concat regex "[^"(regexp-quote next-char)"]*")
-                     regex (replace-regexp-in-string "\\]\\*\\[\\^" "" regex)))
-             (setq stack (cons (cons filter regex) stack))))
-          (when next-char
-            (add-to-invisibility-spec 'sunrise-narrow)
-            (let ((inhibit-read-only t))
-              (save-excursion
-                (goto-char (point-min))
-                (while (not (eobp))
-                  (let* ((start (dired-move-to-filename))
-                         (end (and start (dired-move-to-end-of-filename t))))
-                    (when (and start end)
-                      (let ((old (get-text-property start 'invisible)))
-                        (put-text-property
-                         (point-at-bol) (1+ (point-at-eol)) 'invisible
-                         (if (string-match-p
-                              regex (buffer-substring-no-properties start end))
-                             (cl-set-difference old '(sunrise-narrow))
-                           (cl-union old '(sunrise-narrow)))))))
-                  (goto-char (point-at-bol))
-                  (forward-line 1))))
-            (setq next-char (read-next filter))))))))
+  (assert sunrise-running)
+  (sunrise-beginning-of-buffer)
+  (let ((stack nil) (filter "") (regex "") (next-char nil) (inhibit-quit t))
+    (cl-labels ((read-next (f) (read-char (concat "Fuzzy narrow: " f))))
+      (setq next-char (read-next filter))
+      (sunrise-backup-buffer)
+      (while next-char
+        (cl-case next-char
+          ((?\e ?\C-g) (setq next-char nil) (sunrise-revert-buffer))
+          (?\C-n (setq next-char nil) (sunrise-beginning-of-buffer))
+          (?\C-p (setq next-char nil) (sunrise-end-of-buffer))
+          ((?\n ?\r) (setq next-char nil))
+          ((?\b ?\d)
+           (revert-buffer)
+           (setq stack (cdr stack) filter (caar stack) regex (cdar stack))
+           (unless stack (setq next-char nil)))
+          (t
+           (setq filter (concat filter (char-to-string next-char)))
+           (if (not (eq next-char sunrise-fuzzy-negation-character))
+               (setq next-char (char-to-string next-char)
+                     regex (if (string= "" regex) ".*" regex)
+                     regex (concat regex (regexp-quote next-char) ".*"))
+             (setq next-char (char-to-string (read-next filter))
+                   filter (concat filter next-char)
+                   regex (replace-regexp-in-string "\\.\\*\\'" "" regex)
+                   regex (concat regex "[^"(regexp-quote next-char)"]*")
+                   regex (replace-regexp-in-string "\\]\\*\\[\\^" "" regex)))
+           (setq stack (cons (cons filter regex) stack))))
+        (when next-char
+          (add-to-invisibility-spec 'sunrise-narrow)
+          (let ((inhibit-read-only t))
+            (save-excursion
+              (goto-char (point-min))
+              (while (not (eobp))
+                (let* ((start (dired-move-to-filename))
+                       (end (and start (dired-move-to-end-of-filename t))))
+                  (when (and start end)
+                    (let ((old (get-text-property start 'invisible)))
+                      (put-text-property
+                       (point-at-bol) (1+ (point-at-eol)) 'invisible
+                       (if (string-match-p
+                            regex (buffer-substring-no-properties start end))
+                           (cl-set-difference old '(sunrise-narrow))
+                         (cl-union old '(sunrise-narrow)))))))
+                (goto-char (point-at-bol))
+                (forward-line 1))))
+          (setq next-char (read-next filter)))))))
 
 (defun sunrise-recent-files ()
   "Display the history of recent files in Sunrise virtual mode."

--- a/sunrise.el
+++ b/sunrise.el
@@ -1474,7 +1474,7 @@ path line."
           (setq end (point)
                 next (search-forward sunrise-avfs-root (point-at-eol) t)))
         (when end
-          (add-text-properties start end '(invisible t))))))
+          (put-text-property start end 'invisible t)))))
 
 (defun sunrise-highlight-broken-links ()
   "Mark broken symlinks with an exclamation mark."
@@ -1495,7 +1495,6 @@ Returns t if the overlay is no longer valid and should be replaced."
   "Set up the graphical path line in the current buffer.
 \(Fancy fonts and clickable path.)"
   (let ((begin) (end) (inhibit-read-only t))
-
     (when (sunrise-invalid-overlayp)
       ;;determine begining and end
       (save-excursion
@@ -1512,12 +1511,8 @@ Returns t if the overlay is no longer valid and should be replaced."
            (make-overlay begin end))
 
       ;;path line hover effect:
-      (add-text-properties
-       begin
-       end
-       '(mouse-face sunrise-highlight-path-face
-                    help-echo "click to move up")
-       nil))
+      (put-text-property begin end 'mouse-face 'sunrise-highlight-path-face)
+      (put-text-property begin end 'help-echo "click to move up"))
     (when face
       (setq sunrise-current-path-faces (cons face sunrise-current-path-faces)))
     (overlay-put sunrise-current-window-overlay 'face
@@ -2341,7 +2336,7 @@ Kills any other buffer opened previously the same way."
   "Manage the hiding of attributes in region from BEG to END.
 Selective hiding of specific attributes can be controlled by customizing the
 `sunrise-attributes-display-mask' variable."
-  (let ((cursor beg) props)
+  (let ((cursor beg))
     (cl-labels ((sunrise-make-display-props
                  (display-function-or-flag)
                  (cond ((functionp display-function-or-flag)
@@ -2356,14 +2351,13 @@ Selective hiding of specific attributes can be controlled by customizing the
                     (search-forward-regexp "\\w")
                     (search-forward-regexp "\\s-")
                     (forward-char -1)
-                    (setq props (sunrise-make-display-props do-display))
-                    (when props
-                      (add-text-properties cursor (point) props))
+                    (add-text-properties
+                     cursor (point) (sunrise-make-display-props do-display))
                     (setq cursor (point))
                     (if (>= (point) end) (cl-return-from block)))
                   sunrise-attributes-display-mask))
         (unless (>= cursor end)
-          (add-text-properties cursor (1- end) '(invisible t)))))))
+          (put-text-property cursor (1- end) 'invisible t))))))
 
 (defun sunrise-display-attributes (beg end visiblep)
   "Manage the display of file attributes in the region from BEG to END.

--- a/sunrise.el
+++ b/sunrise.el
@@ -1466,15 +1466,15 @@ path line."
 
 (defun sunrise-hide-avfs-root ()
   "Hide the AVFS virtual filesystem root (if any) on the path line."
-  (if sunrise-avfs-root
-      (let ((start nil) (end nil)
-            (next (search-forward sunrise-avfs-root (point-at-eol) t)))
-        (if next (setq start (- next (length sunrise-avfs-root))))
-        (while next
-          (setq end (point)
-                next (search-forward sunrise-avfs-root (point-at-eol) t)))
-        (when end
-          (put-text-property start end 'invisible t)))))
+  (when sunrise-avfs-root
+    (let ((start nil) (end nil)
+          (next (search-forward sunrise-avfs-root (point-at-eol) t)))
+      (if next (setq start (- next (length sunrise-avfs-root))))
+      (while next
+        (setq end (point)
+              next (search-forward sunrise-avfs-root (point-at-eol) t)))
+      (when end
+        (put-text-property start end 'invisible 'sunrise)))))
 
 (defun sunrise-highlight-broken-links ()
   "Mark broken symlinks with an exclamation mark."


### PR DESCRIPTION
* Fix broken sunrise-fuzzy-narrow command (#62) using a `sunrise-narrow` invisibility specifier.
* Use the invisibility specifier `sunrise` instead of the generic `t`