### PR TITLE
Fix sunrise-assert-other always failing

### DIFF
--- a/sunrise.el
+++ b/sunrise.el
@@ -929,7 +929,7 @@ Uses `save-selected-window' internally."
 
 (defun sunrise-assert-other ()
   "Signal an error if we have no other pane."
-  (unless (window-live-p (sunrise-other))
+  (unless (window-live-p (sunrise-other 'window))
     (user-error "No other Sunrise Commander pane")))
 
 (defmacro sunrise-in-other (form)


### PR DESCRIPTION
Previously, sunrise-assert-other would always fail, this is because sunrise-other returns "left" or "right" by default, not a window. Providing the window parameter produces the intended behavior.

This resolves exactly one bug, introduced in #81, wherein sunrise-synchronize-panes would always error out without executing.