### PR TITLE
Add interactive argument to defadvice other-window

### DIFF
--- a/sunrise.el
+++ b/sunrise.el
@@ -1071,7 +1071,7 @@ file attributes are preserved. See the function `enriched-mode'."
 (ad-activate 'select-window)
 
 (defadvice other-window
-    (around sunrise-advice-other-window (count &optional all-frames))
+    (around sunrise-advice-other-window (count &optional all-frames interactive))
   "Select the correct Sunrise Commander pane when switching from other windows."
   (if (or (not sunrise-running) sunrise-ediff-on)
       ad-do-it


### PR DESCRIPTION
Emacs `master` has a new `interactive` argument for `other-window` which broke Sunrise Commander's `defadvice` surrounding the function.

This change has been tested against  a freshly compiled Emacs `master` as well as an old copy of Emacs 24 in my distribution's official repositories.