### PR TITLE
WIP: Fixing window configuration issues

### DIFF
--- a/sunrise.el
+++ b/sunrise.el
@@ -1389,9 +1389,9 @@ Set SYMBOL to VALUE whenever the option is set."
 ;;; ============================================================================
 ;;; Initialization and finalization functions:
 
-(defun sunrise-show (&optional left-directory right-directory filename)
+(defun sunrise-show (&optional a b filename)
   "Ensure the Sunrise Commander is shown with the given directories.
-LEFT-DIRECTORY and RIGHT-DIRECTORY say which directory to display
+A and B say which directory to display
 in the left and right pane, respectively.  Pass nil to keep the
 current directory (in case Sunrise was already running) or go to
 the home directory (in case Sunrise is started afresh).
@@ -1402,10 +1402,7 @@ If FILENAME is non-nil, it is the basename of a file to focus."
       (set-window-configuration sunrise-last-window-configuration))
   (let ((msg nil))
     (when (or filename
-              (sunrise-ensure-windows
-               (selected-frame)
-               left-directory
-               right-directory))
+              (sunrise-ensure-windows (selected-frame) a b))
       (setq msg sunrise-start-message))
     (when filename
       (condition-case err

--- a/sunrise.el
+++ b/sunrise.el
@@ -2103,7 +2103,8 @@ WILDCARDS is passed to `sunrise-find-regular-file'."
   "Deactivate Sunrise and display BUFFER in the current frame."
   (sunrise-save-panes-width)
   (sunrise-quit)
-  (sunrise-restore-prior-configuration)
+  (when sunrise-prior-window-configuration
+    (sunrise-restore-prior-configuration))
   (switch-to-buffer buffer))
 
 (defun sunrise-avfs-dir (filename)

--- a/sunrise.el
+++ b/sunrise.el
@@ -1427,9 +1427,10 @@ If FILENAME is non-nil, it is the basename of a file to focus."
   (sunrise-bury-panes)
   (sunrise-setup nil))
 
-(defun sunrise-setup (save-window-configuration)
-  (if save-window-configuration
-      (setq sunrise-prior-window-configuration (current-window-configuration)))
+(defun sunrise-setup (first-time)
+  (when first-time
+    (run-hooks 'sunrise-init-hook)
+    (setq sunrise-prior-window-configuration (current-window-configuration)))
   (cond ((eq sunrise-selected-window 'a)
          (sunrise-show sunrise-this-directory sunrise-other-directory))
         ((eq sunrise-selected-window 'b)

--- a/sunrise.el
+++ b/sunrise.el
@@ -1412,7 +1412,7 @@ If FILENAME is non-nil, it is the basename of a file to focus."
           (sunrise-focus-filename (file-name-nondirectory filename))
         (error (setq msg (error-message-string err)))))
     (setq sunrise-this-directory default-directory)
-    (sunrise-highlight)                 ; W32Emacs needs this.
+    (sunrise-highlight)  ; W32Emacs needs this.
     (hl-line-mode 1)
     (message "%s" msg)))
 
@@ -1815,11 +1815,9 @@ Emacs window configuration into a default state."
               (setq sunrise-last-window-configuration (current-window-configuration))
               (sunrise-save-directories)
               (sunrise-save-panes-width)
-              (if (or norestore (not (sunrise-restore-prior-configuration)))
-                  (progn
-                    (sunrise-select-viewer-window)
-                    (delete-other-windows))
-                (set-window-configuration sunrise-prior-window-configuration))
+              (when (or norestore (not (sunrise-restore-prior-configuration)))
+                (sunrise-select-viewer-window)
+                (delete-other-windows))
               (sunrise-bury-panes)
               (message "All life leaps out to greet the light...")
               (run-hooks 'sunrise-quit-hook)


### PR DESCRIPTION
I know this isn't a clean PR yet and has some hacks, but I just wanted to get it out there. These changes have gotten Sunrise Commander to exhibit most of its old behavior in terms of restoring panes. Some of the bugs I am trying to fix are documented in #115 

Basically, on Emacs 28, Sunrise Commander has the current bugs:

- Constantly creates new panes and never reuses old ones
- Never remembers the pre `(sunrise-toggle)` window configuration
- Copying/moving/etc between panes is completely broken

This PR mostly fixes these things.

Some things are wrong though... like, we should be opening the active pane directory based on the currently active buffer, I think. And some of my work in sunrise-quit is redundant. And I don't think I'm focusing on the right buffer for the "view panel".