### PR TITLE
Add missing autoload comment for function sunrise-toggle

### DIFF
--- a/sunrise.el
+++ b/sunrise.el
@@ -1412,6 +1412,7 @@ If FILENAME is non-nil, it is the basename of a file to focus."
     (hl-line-mode 1)
     (message "%s" msg)))
 
+;;;###autoload
 (defun sunrise-toggle ()
   "Show or hide the Sunrise Commander."
   (interactive)


### PR DESCRIPTION
This just allows to start *sunrise* with the `sunrise-toggle` command.